### PR TITLE
Fixed 'make check'

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,247 @@
+[style]
+# Align closing bracket with visual indentation.
+align_closing_bracket_with_visual_indent=True
+
+# Allow dictionary keys to exist on multiple lines. For example:
+#
+#   x = {
+#       ('this is the first element of a tuple',
+#        'this is the second element of a tuple'):
+#            value,
+#   }
+allow_multiline_dictionary_keys=False
+
+# Allow lambdas to be formatted on more than one line.
+allow_multiline_lambdas=False
+
+# Allow splits before the dictionary value.
+allow_split_before_dict_value=True
+
+# Number of blank lines surrounding top-level function and class
+# definitions.
+blank_lines_around_top_level_definition=2
+
+# Insert a blank line before a class-level docstring.
+blank_line_before_class_docstring=False
+
+# Insert a blank line before a module docstring.
+blank_line_before_module_docstring=False
+
+# Insert a blank line before a 'def' or 'class' immediately nested
+# within another 'def' or 'class'. For example:
+#
+#   class Foo:
+#                      # <------ this blank line
+#     def method():
+#       ...
+blank_line_before_nested_class_or_def=False
+
+# Do not split consecutive brackets. Only relevant when
+# dedent_closing_brackets is set. For example:
+#
+#    call_func_that_takes_a_dict(
+#        {
+#            'key1': 'value1',
+#            'key2': 'value2',
+#        }
+#    )
+#
+# would reformat to:
+#
+#    call_func_that_takes_a_dict({
+#        'key1': 'value1',
+#        'key2': 'value2',
+#    })
+coalesce_brackets=True
+
+# The column limit.
+column_limit=100
+
+# The style for continuation alignment. Possible values are:
+#
+# - SPACE: Use spaces for continuation alignment. This is default behavior.
+# - FIXED: Use fixed number (CONTINUATION_INDENT_WIDTH) of columns
+#   (ie: CONTINUATION_INDENT_WIDTH/INDENT_WIDTH tabs) for continuation
+#   alignment.
+# - LESS: Slightly left if cannot vertically align continuation lines with
+#   indent characters.
+# - VALIGN-RIGHT: Vertically align continuation lines with indent
+#   characters. Slightly right (one more indent character) if cannot
+#   vertically align continuation lines with indent characters.
+#
+# For options FIXED, and VALIGN-RIGHT are only available when USE_TABS is
+# enabled.
+continuation_align_style=SPACE
+
+# Indent width used for line continuations.
+continuation_indent_width=4
+
+# Put closing brackets on a separate line, dedented, if the bracketed
+# expression can't fit in a single line. Applies to all kinds of brackets,
+# including function definitions and calls. For example:
+#
+#   config = {
+#       'key1': 'value1',
+#       'key2': 'value2',
+#   }        # <--- this bracket is dedented and on a separate line
+#
+#   time_series = self.remote_client.query_entity_counters(
+#       entity='dev3246.region1',
+#       key='dns.query_latency_tcp',
+#       transform=Transformation.AVERAGE(window=timedelta(seconds=60)),
+#       start_ts=now()-timedelta(days=3),
+#       end_ts=now(),
+#   )        # <--- this bracket is dedented and on a separate line
+dedent_closing_brackets=True
+
+# Place each dictionary entry onto its own line.
+each_dict_entry_on_separate_line=False
+
+# The regex for an i18n comment. The presence of this comment stops
+# reformatting of that line, because the comments are required to be
+# next to the string they translate.
+i18n_comment=
+
+# The i18n function call names. The presence of this function stops
+# reformattting on that line, because the string it has cannot be moved
+# away from the i18n comment.
+i18n_function_call=
+
+# Indent the dictionary value if it cannot fit on the same line as the
+# dictionary key. For example:
+#
+#   config = {
+#       'key1':
+#           'value1',
+#       'key2': value1 +
+#               value2,
+#   }
+indent_dictionary_value=False
+
+# The number of columns to use for indentation.
+indent_width=4
+
+# Join short lines into one line. E.g., single line 'if' statements.
+join_multiple_lines=False
+
+# Do not include spaces around selected binary operators. For example:
+#
+#   1 + 2 * 3 - 4 / 5
+#
+# will be formatted as follows when configured with a value "*,/":
+#
+#   1 + 2*3 - 4/5
+#
+no_spaces_around_selected_binary_operators=set()
+
+# Use spaces around default or named assigns.
+spaces_around_default_or_named_assign=False
+
+# Use spaces around the power operator.
+spaces_around_power_operator=False
+
+# The number of spaces required before a trailing comment.
+spaces_before_comment=2
+
+# Insert a space between the ending comma and closing bracket of a list,
+# etc.
+space_between_ending_comma_and_closing_bracket=True
+
+# Split before arguments
+split_all_comma_separated_values=False
+
+# Split before arguments if the argument list is terminated by a
+# comma.
+split_arguments_when_comma_terminated=False
+
+# Set to True to prefer splitting before '&', '|' or '^' rather than
+# after.
+split_before_bitwise_operator=True
+
+# Split before the closing bracket if a list or dict literal doesn't fit on
+# a single line.
+split_before_closing_bracket=True
+
+# Split before a dictionary or set generator (comp_for). For example, note
+# the split before the 'for':
+#
+#   foo = {
+#       variable: 'Hello world, have a nice day!'
+#       for variable in bar if variable != 42
+#   }
+split_before_dict_set_generator=True
+
+# Split after the opening paren which surrounds an expression if it doesn't
+# fit on a single line.
+split_before_expression_after_opening_paren=False
+
+# If an argument / parameter list is going to be split, then split before
+# the first argument.
+split_before_first_argument=False
+
+# Set to True to prefer splitting before 'and' or 'or' rather than
+# after.
+split_before_logical_operator=True
+
+# Split named assignments onto individual lines.
+split_before_named_assigns=True
+
+# Set to True to split list comprehensions and generators that have
+# non-trivial expressions and multiple clauses before each of these
+# clauses. For example:
+#
+#   result = [
+#       a_long_var + 100 for a_long_var in xrange(1000)
+#       if a_long_var % 10]
+#
+# would reformat to something like:
+#
+#   result = [
+#       a_long_var + 100
+#       for a_long_var in xrange(1000)
+#       if a_long_var % 10]
+split_complex_comprehension=True
+
+# The penalty for splitting right after the opening bracket.
+split_penalty_after_opening_bracket=30
+
+# The penalty for splitting the line after a unary operator.
+split_penalty_after_unary_operator=10000
+
+# The penalty for splitting right before an if expression.
+split_penalty_before_if_expr=0
+
+# The penalty of splitting the line around the '&', '|', and '^'
+# operators.
+split_penalty_bitwise_operator=300
+
+# The penalty for splitting a list comprehension or generator
+# expression.
+split_penalty_comprehension=80
+
+# The penalty for characters over the column limit.
+split_penalty_excess_character=4500
+
+# The penalty incurred by adding a line split to the unwrapped line. The
+# more line splits added the higher the penalty.
+split_penalty_for_added_line_split=30
+
+# The penalty of splitting a list of "import as" names. For example:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (long_argument_1,
+#                                                             long_argument_2,
+#                                                             long_argument_3)
+#
+# would reformat to something like:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (
+#       long_argument_1, long_argument_2, long_argument_3)
+split_penalty_import_names=0
+
+# The penalty of splitting the line around the 'and' and 'or'
+# operators.
+split_penalty_logical_operator=300
+
+# Use the Tab character for indentation.
+use_tabs=False
+

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ help:
 	@echo  "    lint	Reports all linter violations"
 	@echo  "    test	Runs all tests"
 	@echo  "    docs 	Builds the documentation"
+	@echo  "    style       Auto-formats the code"
 
 up:
 	pip-compile -o requirements-dev.txt requirements-dev.in -U
@@ -23,7 +24,6 @@ deps:
 check: deps
 	flake8 $(checkfiles)
 	mypy $(mypy_flags) $(checkfiles)
-	pylint -E $(checkfiles)
 	python setup.py check -mrs
 
 lint: deps
@@ -41,3 +41,7 @@ travis: check test bench
 
 docs: deps
 	python setup.py build_sphinx -E
+
+style: deps
+	yapf -i -r $(checkfiles)
+	isort -rc $(checkfiles)

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,5 +1,3 @@
-import logging
-import sqlite3
 import uuid
 
 

--- a/examples/aggregation.py
+++ b/examples/aggregation.py
@@ -4,7 +4,6 @@ from examples import get_db_name
 from tortoise import Tortoise, fields
 from tortoise.aggregation import Count, Min, Sum
 from tortoise.backends.sqlite.client import SqliteClient
-from tortoise.exceptions import NoValuesFetched
 from tortoise.models import Model
 from tortoise.utils import generate_schema
 
@@ -21,7 +20,9 @@ class Event(Model):
     id = fields.IntField(pk=True)
     name = fields.TextField()
     tournament = fields.ForeignKeyField('models.Tournament', related_name='events')
-    participants = fields.ManyToManyField('models.Team', related_name='events', through='event_team')
+    participants = fields.ManyToManyField(
+        'models.Team', related_name='events', through='event_team'
+    )
 
     def __str__(self):
         return self.name
@@ -56,9 +57,8 @@ async def run():
     await event.participants.add(participants[0], participants[1])
     await event.participants.add(participants[0], participants[1])
 
-    tournaments_with_count = await Tournament.all().annotate(events_count=Count('events')).filter(
-        events_count__gte=1
-    )
+    tournaments_with_count = await Tournament.all().annotate(events_count=Count('events')
+                                                             ).filter(events_count__gte=1)
     assert len(tournaments_with_count) == 1 and tournaments_with_count[0].events_count == 2
 
     event_with_lowest_team_id = await Event.filter(id=event.id).first().annotate(
@@ -66,9 +66,11 @@ async def run():
     )
     assert event_with_lowest_team_id.lowest_team_id == participants[0].id
 
-    ordered_tournaments = await Tournament.all().annotate(events_count=Count('events')).order_by('events_count')
+    ordered_tournaments = await Tournament.all().annotate(events_count=Count('events')
+                                                          ).order_by('events_count')
     assert len(ordered_tournaments) == 2 and ordered_tournaments[1].id == tournament.id
-    event_with_annotation = await Event.all().annotate(tournament_test_id=Sum('tournament__id')).first()
+    event_with_annotation = await Event.all().annotate(tournament_test_id=Sum('tournament__id')
+                                                       ).first()
     assert event_with_annotation.tournament_test_id == event_with_annotation.tournament_id
 
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,3 +1,6 @@
+"""
+This example demonstrates most basic operations with single model
+"""
 import asyncio
 
 from examples import get_db_name
@@ -5,10 +8,6 @@ from tortoise import Tortoise, fields
 from tortoise.backends.sqlite.client import SqliteClient
 from tortoise.models import Model
 from tortoise.utils import generate_schema
-
-"""
-This example demonstrates most basic operations with single model
-"""
 
 
 class Event(Model):

--- a/examples/complex_prefetching.py
+++ b/examples/complex_prefetching.py
@@ -4,7 +4,7 @@ from examples import get_db_name
 from tortoise import Tortoise, fields
 from tortoise.backends.sqlite.client import SqliteClient
 from tortoise.models import Model
-from tortoise.query_utils import Q, Prefetch
+from tortoise.query_utils import Prefetch
 from tortoise.utils import generate_schema
 
 
@@ -20,7 +20,9 @@ class Event(Model):
     id = fields.IntField(pk=True)
     name = fields.TextField()
     tournament = fields.ForeignKeyField('models.Tournament', related_name='events')
-    participants = fields.ManyToManyField('models.Team', related_name='events', through='event_team')
+    participants = fields.ManyToManyField(
+        'models.Team', related_name='events', through='event_team'
+    )
 
     def __str__(self):
         return self.name

--- a/examples/postgres.py
+++ b/examples/postgres.py
@@ -1,22 +1,16 @@
+"""
+This example showcases special postgres features
+"""
 import asyncio
-import uuid
 from copy import copy
 
 from asyncpg import InvalidCatalogNameError
 
-from examples import get_db_name
 from tortoise import Tortoise, fields
-from tortoise.aggregation import Count
 from tortoise.backends.asyncpg.client import AsyncpgDBClient
 from tortoise.backends.asyncpg.fields import JSONField
-from tortoise.backends.sqlite.client import SqliteClient
-from tortoise.exceptions import NoValuesFetched
 from tortoise.models import Model
 from tortoise.utils import generate_schema
-
-"""
-This example showcases special postgres features
-"""
 
 
 class Report(Model):
@@ -42,9 +36,7 @@ async def run():
     await client.create_connection()
 
     try:
-        await client.execute_script(
-            'DROP DATABASE {}'.format(test_db_name)
-        )
+        await client.execute_script('DROP DATABASE {}'.format(test_db_name))
     except InvalidCatalogNameError:
         pass
     await client.execute_script(

--- a/examples/relations.py
+++ b/examples/relations.py
@@ -1,20 +1,18 @@
+"""
+This example shows how relations between models work.
+
+Key points in this example are use of ForeignKeyField and ManyToManyField
+to declare relations and use of .prefetch_related() and .fetch_related()
+to get this related objects
+"""
 import asyncio
 
 from examples import get_db_name
 from tortoise import Tortoise, fields
-from tortoise.aggregation import Count
 from tortoise.backends.sqlite.client import SqliteClient
 from tortoise.exceptions import NoValuesFetched
 from tortoise.models import Model
 from tortoise.utils import generate_schema
-
-"""
-This example shows how relations between models work.
-
-Key points in this example are use of ForeignKeyField and ManyToManyField 
-to declare relations and use of .prefetch_related() and .fetch_related() 
-to get this related objects 
-"""
 
 
 class Tournament(Model):
@@ -29,7 +27,9 @@ class Event(Model):
     id = fields.IntField(pk=True)
     name = fields.TextField()
     tournament = fields.ForeignKeyField('models.Tournament', related_name='events')
-    participants = fields.ManyToManyField('models.Team', related_name='events', through='event_team')
+    participants = fields.ManyToManyField(
+        'models.Team', related_name='events', through='event_team'
+    )
 
     def __str__(self):
         return self.name
@@ -77,9 +77,8 @@ async def run():
 
     assert event.participants[0].id == participants[0].id
 
-    selected_events = await Event.filter(
-        participants=participants[0].id
-    ).prefetch_related('participants', 'tournament')
+    selected_events = await Event.filter(participants=participants[0].id
+                                         ).prefetch_related('participants', 'tournament')
     assert len(selected_events) == 1
     assert selected_events[0].tournament.id == tournament.id
     assert len(selected_events[0].participants) == 2

--- a/examples/schema_create.py
+++ b/examples/schema_create.py
@@ -1,5 +1,4 @@
 import asyncio
-
 import datetime
 import secrets
 
@@ -27,7 +26,9 @@ class Event(Model):
     id = fields.IntField(pk=True)
     name = fields.TextField(unique=True)
     tournament = fields.ForeignKeyField('models.Tournament', related_name='events')
-    participants = fields.ManyToManyField('models.Team', related_name='events', through='event_team')
+    participants = fields.ManyToManyField(
+        'models.Team', related_name='events', through='event_team'
+    )
     modified = fields.DatetimeField(auto_now=True)
     prize = fields.DecimalField(max_digits=10, decimal_places=2, null=True)
     token = fields.TextField(default=generate_token)

--- a/examples/transactions.py
+++ b/examples/transactions.py
@@ -1,3 +1,10 @@
+"""
+This example demonstrates how you can use transactions with tortoise
+
+Currently tortoise doesn't have some kind of magic transaction wrapper
+like django's transaction.atomic, but if you have to make something in transaction
+you could still do it like this
+"""
 import asyncio
 import sqlite3
 
@@ -6,14 +13,6 @@ from tortoise import Tortoise, fields
 from tortoise.backends.sqlite.client import SqliteClient
 from tortoise.models import Model
 from tortoise.utils import generate_schema
-
-"""
-This example demonstrates how you can use transactions with tortoise
-
-Currently tortoise doesn't have some kind of magic transaction wrapper
-like django's transaction.atomic, but if you have to make something in transaction 
-you could still do it like this
-"""
 
 
 class Event(Model):

--- a/examples/two_databases.py
+++ b/examples/two_databases.py
@@ -1,12 +1,3 @@
-import asyncio
-from sqlite3 import OperationalError
-
-from examples import get_db_name
-from tortoise import Tortoise, fields
-from tortoise.backends.sqlite.client import SqliteClient
-from tortoise.models import Model
-from tortoise.utils import generate_schema
-
 """
 This example demonstrates how you can use Tortoise if you have to
 separate databases
@@ -17,6 +8,14 @@ use relations between two databases
 Key notes of this example is using db_route for Tortoise init
 and explicitly declaring model apps in class Meta
 """
+import asyncio
+from sqlite3 import OperationalError
+
+from examples import get_db_name
+from tortoise import Tortoise, fields
+from tortoise.backends.sqlite.client import SqliteClient
+from tortoise.models import Model
+from tortoise.utils import generate_schema
 
 
 class Tournament(Model):
@@ -35,7 +34,9 @@ class Event(Model):
     name = fields.TextField()
     tournament_id = fields.IntField()
     # Here we make link to events.Team, not models.Team
-    participants = fields.ManyToManyField('events.Team', related_name='events', through='event_team')
+    participants = fields.ManyToManyField(
+        'events.Team', related_name='events', through='event_team'
+    )
 
     def __str__(self):
         return self.name

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -18,6 +18,7 @@ flake8-isort
 pylint
 docutils
 pygments
+yapf
 
 ## Test tools
 tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ mypy==0.610
 packaging==17.1           # via sphinx
 pip-tools==2.0.2
 pluggy==0.6.0             # via tox
-py==1.5.3                 # via tox
+py==1.5.4                 # via tox
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.6.0           # via flake8
 pygments==2.2.0
@@ -47,3 +47,4 @@ typed-ast==1.1.0          # via mypy
 urllib3==1.23             # via requests
 virtualenv==16.0.0        # via tox
 wrapt==1.10.11            # via astroid
+yapf==0.22.0

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 # coding: utf8
 
 import ast
-
 import sys
-from setuptools import setup
 
+from setuptools import setup
 
 if sys.version_info < (3, 5, 3):
     raise RuntimeError("tortoise requires Python 3.5.3+")
@@ -41,7 +40,6 @@ def version():
 with open('requirements.txt') as f:
     required = f.read().splitlines()
 
-
 setup(
     # Application name:
     name="tortoise-orm",
@@ -64,10 +62,8 @@ setup(
 
     # Details
     url="https://github.com/Zeliboba5/tortoise-orm",
-
     description="Easy async ORM for python, built with relations in mind",
     long_description=readme(),
-
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Development Status :: 5 - Production/Stable',

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -1,13 +1,13 @@
 from tortoise import fields
 from tortoise.backends.base.client import BaseDBAsyncClient
-from tortoise.exceptions import MultiplyObjectsReturned
-from tortoise.fields import ManyToManyRelationManager
+from tortoise.exceptions import MultiplyObjectsReturned  # noqa
+from tortoise.fields import ManyToManyRelationManager  # noqa
 from tortoise.models import get_backward_fk_filters, get_m2m_filters
-from tortoise.queryset import QuerySet
+from tortoise.queryset import QuerySet  # noqa
 
 
 class Tortoise:
-    apps = {}
+    apps = {}  # type: dict
     _inited = False
     _db_routing = None
     _global_connection = None
@@ -63,8 +63,7 @@ class Tortoise:
                         backward_relation_name = '{}s'.format(model._meta.table)
                     assert backward_relation_name not in related_model._meta.fields, (
                         'backward relation "{}" duplicates in model {}'.format(
-                            backward_relation_name,
-                            related_model_name
+                            backward_relation_name, related_model_name
                         )
                     )
                     relation = fields.BackwardFKRelation(model, '{}_id'.format(field))
@@ -99,8 +98,7 @@ class Tortoise:
                         backward_relation_name = '{}s'.format(model._meta.table)
                     assert backward_relation_name not in related_model._meta.fields, (
                         'backward relation "{}" duplicates in model {}'.format(
-                            backward_relation_name,
-                            related_model_name
+                            backward_relation_name, related_model_name
                         )
                     )
                     relation = fields.ManyToManyField(
@@ -118,7 +116,9 @@ class Tortoise:
                         relation,
                     )
                     model._meta.filters.update(get_m2m_filters(field, field_object))
-                    related_model._meta.filters.update(get_m2m_filters(backward_relation_name, relation))
+                    related_model._meta.filters.update(
+                        get_m2m_filters(backward_relation_name, relation)
+                    )
                     related_model._meta.m2m_fields.add(backward_relation_name)
                     related_model._meta.fetch_fields.add(backward_relation_name)
                     related_model._meta.fields_map[backward_relation_name] = relation

--- a/tortoise/aggregation.py
+++ b/tortoise/aggregation.py
@@ -1,9 +1,9 @@
 from pypika import Table
-from pypika.functions import Count as PypikaCount
-from pypika.functions import Sum as PypikaSum
-from pypika.functions import Min as PypikaMin
-from pypika.functions import Max as PypikaMax
 from pypika.functions import Avg as PypikaAvg
+from pypika.functions import Count as PypikaCount
+from pypika.functions import Max as PypikaMax
+from pypika.functions import Min as PypikaMin
+from pypika.functions import Sum as PypikaSum
 
 
 class Aggregate:
@@ -23,15 +23,21 @@ class Aggregate:
                 related_field = model._meta.fields_map[field_split[0]]
                 join = (Table(model._meta.table), field_split[0], related_field)
                 aggregation['joins'].append(join)
-                aggregation['field'] = self.aggregation_func(Table(related_field.type._meta.table).id)
+                aggregation['field'] = self.aggregation_func(
+                    Table(related_field.type._meta.table).id
+                )
             else:
-                aggregation['field'] = self.aggregation_func(getattr(Table(model._meta.table), field_split[0]))
+                aggregation['field'] = self.aggregation_func(
+                    getattr(Table(model._meta.table), field_split[0])
+                )
             return aggregation
         else:
             assert field_split[0] in model._meta.fetch_fields
             related_field = model._meta.fields_map[field_split[0]]
             join = (Table(model._meta.table), field_split[0], related_field)
-            aggregation = self._resolve_field_for_model('__'.join(field_split[1:]), related_field.type)
+            aggregation = self._resolve_field_for_model(
+                '__'.join(field_split[1:]), related_field.type
+            )
             aggregation['joins'].append(join)
             return aggregation
 

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -1,16 +1,12 @@
 import logging
 
-import asyncio
 import asyncpg
-from datetime import date
-
-from aenum import Enum
 from pypika import PostgreSQLQuery
-from pypika.terms import ValueWrapper, basestring
 
 from tortoise.backends.asyncpg.executor import AsyncpgExecutor
 from tortoise.backends.asyncpg.schema_generator import AsyncpgSchemaGenerator
-from tortoise.backends.base.client import BaseDBAsyncClient, ConnectionWrapper, SingleConnectionWrapper
+from tortoise.backends.base.client import (BaseDBAsyncClient, ConnectionWrapper,
+                                           SingleConnectionWrapper)
 
 
 class AsyncpgDBClient(BaseDBAsyncClient):
@@ -38,7 +34,9 @@ class AsyncpgDBClient(BaseDBAsyncClient):
         self._db_pool = None
         self._connection = None
 
-        self._transaction_class = type('TransactionWrapper', (TransactionWrapper, self.__class__), {})
+        self._transaction_class = type(
+            'TransactionWrapper', (TransactionWrapper, self.__class__), {}
+        )
 
     async def create_connection(self):
         if not self.single_connection:
@@ -48,10 +46,7 @@ class AsyncpgDBClient(BaseDBAsyncClient):
         self.log.debug(
             'Created connection with params: '
             'user={user} database={database} host={host} port={port}'.format(
-                user=self.user,
-                database=self.database,
-                host=self.host,
-                port=self.port
+                user=self.user, database=self.database, host=self.host, port=self.port
             )
         )
 
@@ -104,9 +99,7 @@ class TransactionWrapper(AsyncpgDBClient):
         self._pool = pool
         self.single_connection = True
         self._single_connection_class = type(
-            'SingleConnectionWrapper',
-            (SingleConnectionWrapper, self.__class__),
-            {}
+            'SingleConnectionWrapper', (SingleConnectionWrapper, self.__class__), {}
         )
         self._transaction_class = self.__class__
 

--- a/tortoise/backends/asyncpg/executor.py
+++ b/tortoise/backends/asyncpg/executor.py
@@ -1,7 +1,5 @@
-import datetime
 from pypika import Table
 
-from tortoise import fields
 from tortoise.backends.base.executor import BaseExecutor
 
 
@@ -12,10 +10,8 @@ class AsyncpgExecutor(BaseExecutor):
         values = self._prepare_insert_values(instance, columns, generated_columns)
 
         query = (
-            self.connection.query_class.into(Table(self.model._meta.table))
-            .columns(*columns)
-            .insert(*values)
-            .returning('id')
+            self.connection.query_class.into(Table(self.model._meta.table)).columns(*columns)
+            .insert(*values).returning('id')
         )
         result = await self.connection.execute_query(str(query))
         instance.id = result[0][0]

--- a/tortoise/backends/asyncpg/schema_generator.py
+++ b/tortoise/backends/asyncpg/schema_generator.py
@@ -5,9 +5,7 @@ from tortoise.backends.base.schema_generator import BaseSchemaGenerator
 class AsyncpgSchemaGenerator(BaseSchemaGenerator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.FIELD_TYPE_MAP.update({
-            JSONField: 'jsonb'
-        })
+        self.FIELD_TYPE_MAP.update({JSONField: 'jsonb'})
 
     def _get_primary_key_create_string(self, field_name):
         return '"{}" SERIAL NOT NULL PRIMARY KEY'.format(field_name)

--- a/tortoise/backends/base/client.py
+++ b/tortoise/backends/base/client.py
@@ -15,9 +15,7 @@ class BaseDBAsyncClient:
         self.log = logging.getLogger('db_client')
         self.single_connection = single_connection
         self._single_connection_class = type(
-            'SingleConnectionWrapper',
-            (SingleConnectionWrapper, self.__class__),
-            {}
+            'SingleConnectionWrapper', (SingleConnectionWrapper, self.__class__), {}
         )
 
     async def create_connection(self):

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -1,4 +1,5 @@
 import datetime
+
 from pypika import Table
 
 from tortoise import fields
@@ -44,16 +45,15 @@ class BaseExecutor:
 
     def _get_prepared_value(self, instance, field):
         field_object = self.model._meta.fields_map[field]
-        return field_object.to_db_value(getattr(
-            instance,
-            self.model._meta.fields_db_projection_reverse[field],
-        ))
+        return field_object.to_db_value(
+            getattr(
+                instance,
+                self.model._meta.fields_db_projection_reverse[field],
+            )
+        )
 
     def _prepare_insert_values(self, instance, columns, generated_columns):
-        values = [
-            self._get_prepared_value(instance, column)
-            for column in columns
-        ]
+        values = [self._get_prepared_value(instance, column) for column in columns]
         for column, value in generated_columns:
             columns.append(column)
             values.append(value)
@@ -99,9 +99,9 @@ class BaseExecutor:
         backward_relation_manager = getattr(self.model, field)
         relation_field = backward_relation_manager.relation_field
 
-        related_object_list = await related_query.filter(**{
-            '{}__in'.format(relation_field): list(instance_id_set)
-        })
+        related_object_list = await related_query.filter(
+            **{'{}__in'.format(relation_field): list(instance_id_set)}
+        )
 
         related_object_map = {}
         for entry in related_object_list:
@@ -167,7 +167,9 @@ class BaseExecutor:
             related_object_list = await related_query.filter(id__in=list(related_objects_for_fetch))
             related_object_map = {obj.id: obj for obj in related_object_list}
             for instance in instance_list:
-                setattr(instance, field, related_object_map.get(getattr(instance, relation_key_field)))
+                setattr(
+                    instance, field, related_object_map.get(getattr(instance, relation_key_field))
+                )
         return instance_list
 
     def _make_prefetch_queries(self):
@@ -204,7 +206,7 @@ class BaseExecutor:
             relation_split = relation.split('__')
             first_level_field = relation_split[0]
             assert (
-                    first_level_field in self.model._meta.fetch_fields
+                first_level_field in self.model._meta.fetch_fields
             ), 'relation {} for {} not found'.format(first_level_field, self.model._meta.table)
             if first_level_field not in self.prefetch_map.keys():
                 self.prefetch_map[first_level_field] = set()

--- a/tortoise/backends/base/schema_generator.py
+++ b/tortoise/backends/base/schema_generator.py
@@ -66,21 +66,20 @@ class BaseSchemaGenerator:
             fields_to_create.append(field_creation_string)
 
         table_fields_string = ', '.join(fields_to_create)
-        table_create_string = TABLE_CREATE_TEMPLATE.format(
-            model._meta.table,
-            table_fields_string
-        )
+        table_create_string = TABLE_CREATE_TEMPLATE.format(model._meta.table, table_fields_string)
 
         for m2m_field in model._meta.m2m_fields:
             field_object = model._meta.fields_map[m2m_field]
             if field_object._generated:
                 continue
-            m2m_tables_for_create.append(M2M_TABLE_TEMPLATE.format(
-                backward_table=model._meta.table,
-                forward_table=field_object.type._meta.table,
-                backward_key=field_object.backward_key,
-                forward_key=field_object.forward_key,
-            ))
+            m2m_tables_for_create.append(
+                M2M_TABLE_TEMPLATE.format(
+                    backward_table=model._meta.table,
+                    forward_table=field_object.type._meta.table,
+                    backward_key=field_object.backward_key,
+                    forward_key=field_object.forward_key,
+                )
+            )
 
         return {
             'table': model._meta.table,
@@ -127,4 +126,3 @@ class BaseSchemaGenerator:
 
     async def generate_from_string(self, creation_string):
         await self.client.execute_script(creation_string)
-

--- a/tortoise/backends/sqlite/client.py
+++ b/tortoise/backends/sqlite/client.py
@@ -16,11 +16,11 @@ class SqliteClient(BaseDBAsyncClient):
     def __init__(self, filename, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.filename = filename
-        self._transaction_class = type('TransactionWrapper', (TransactionWrapper, self.__class__), {})
+        self._transaction_class = type(
+            'TransactionWrapper', (TransactionWrapper, self.__class__), {}
+        )
         self._single_connection_class = type(
-            'SingleConnectionWrapper',
-            (SingleConnectionWrapper, self.__class__),
-            {}
+            'SingleConnectionWrapper', (SingleConnectionWrapper, self.__class__), {}
         )
 
     async def create_connection(self):
@@ -73,9 +73,7 @@ class TransactionWrapper(SqliteClient):
         self.log = logging.getLogger('db_client')
         self.single_connection = True
         self._single_connection_class = type(
-            'SingleConnectionWrapper',
-            (SingleConnectionWrapper, self.__class__),
-            {}
+            'SingleConnectionWrapper', (SingleConnectionWrapper, self.__class__), {}
         )
         self._transaction_class = self.__class__
 

--- a/tortoise/backends/sqlite/executor.py
+++ b/tortoise/backends/sqlite/executor.py
@@ -1,7 +1,5 @@
-import datetime
 from pypika import Table
 
-from tortoise import fields
 from tortoise.backends.base.executor import BaseExecutor
 
 
@@ -12,8 +10,7 @@ class SqliteExecutor(BaseExecutor):
         values = self._prepare_insert_values(instance, columns, generated_columns)
 
         query = (
-            self.connection.query_class.into(Table(self.model._meta.table))
-            .columns(*columns)
+            self.connection.query_class.into(Table(self.model._meta.table)).columns(*columns)
             .insert(*values)
         )
         result = await self.connection.execute_query(str(query), get_inserted_id=True)

--- a/tortoise/fields.py
+++ b/tortoise/fields.py
@@ -1,12 +1,10 @@
-import decimal
-
 import datetime
+import decimal
 
 from pypika import Table
 
 from tortoise.exceptions import NoValuesFetched
 from tortoise.utils import AsyncIteratorWrapper
-
 
 CASCADE = 'CASCADE'
 RESTRICT = 'RESTRICT'
@@ -15,8 +13,18 @@ SET_DEFAULT = 'SET DEFAULT'
 
 
 class Field:
-    def __init__(self, type=None, source_field=None, generated=False, pk=False,
-                 null=False, default=None, unique=False, *args, **kwargs):
+    def __init__(
+        self,
+        type=None,
+        source_field=None,
+        generated=False,
+        pk=False,
+        null=False,
+        default=None,
+        unique=False,
+        *args,
+        **kwargs
+    ):
         self.type = type
         self.source_field = source_field
         self.generated = generated
@@ -107,12 +115,24 @@ class ForeignKeyField(Field):
 
 
 class ManyToManyField(Field):
-    def __init__(self, model_name, through, forward_key=None, backward_key=None, related_name=None, *args, **kwargs):
+    def __init__(
+        self,
+        model_name,
+        through,
+        forward_key=None,
+        backward_key=None,
+        related_name=None,
+        *args,
+        **kwargs
+    ):
         super().__init__(*args, **kwargs)
-        assert len(model_name.split(".")) == 2, 'Foreign key accepts model name in format "app.Model"'
+        assert len(model_name.split(".")
+                   ) == 2, 'Foreign key accepts model name in format "app.Model"'
         self.model_name = model_name
         self.related_name = related_name
-        self.forward_key = forward_key if forward_key else '{}_id'.format(model_name.split(".")[1].lower())
+        self.forward_key = forward_key if forward_key else '{}_id'.format(
+            model_name.split(".")[1].lower()
+        )
         self.backward_key = backward_key
         self.through = through
         self._generated = False
@@ -142,27 +162,37 @@ class RelationQueryContainer:
 
     def __contains__(self, item):
         if not self._fetched:
-            raise NoValuesFetched('No values were fetched for this relation, first use .fetch_related()')
+            raise NoValuesFetched(
+                'No values were fetched for this relation, first use .fetch_related()'
+            )
         return item in self.related_objects
 
     def __iter__(self):
         if not self._fetched:
-            raise NoValuesFetched('No values were fetched for this relation, first use .fetch_related()')
+            raise NoValuesFetched(
+                'No values were fetched for this relation, first use .fetch_related()'
+            )
         return self.related_objects.__iter__()
 
     def __len__(self):
         if not self._fetched:
-            raise NoValuesFetched('No values were fetched for this relation, first use .fetch_related()')
+            raise NoValuesFetched(
+                'No values were fetched for this relation, first use .fetch_related()'
+            )
         return len(self.related_objects)
 
     def __bool__(self):
         if not self._fetched:
-            raise NoValuesFetched('No values were fetched for this relation, first use .fetch_related()')
+            raise NoValuesFetched(
+                'No values were fetched for this relation, first use .fetch_related()'
+            )
         return bool(self.related_objects)
 
     def __getitem__(self, item):
         if not self._fetched:
-            raise NoValuesFetched('No values were fetched for this relation, first use .fetch_related()')
+            raise NoValuesFetched(
+                'No values were fetched for this relation, first use .fetch_related()'
+            )
         return self.related_objects[item]
 
     async def __aiter__(self):
@@ -218,14 +248,11 @@ class ManyToManyRelationManager(RelationQueryContainer):
         criterion = getattr(through_table, self.field.forward_key) == instances[0].id
         for instance_to_add in instances[1:]:
             criterion |= getattr(through_table, self.field.forward_key) == instance_to_add.id
-        select_query = select_query.where(
-            criterion
-        )
+        select_query = select_query.where(criterion)
 
         already_existing_relations_raw = await db.execute_query(str(select_query))
-        already_existing_relations = set(
-            (r[self.field.backward_key], r[self.field.forward_key]) for r in already_existing_relations_raw
-        )
+        already_existing_relations = set((r[self.field.backward_key], r[self.field.forward_key])
+                                         for r in already_existing_relations_raw)
 
         insert_is_required = False
         for instance_to_add in instances:
@@ -257,9 +284,7 @@ class ManyToManyRelationManager(RelationQueryContainer):
                 getattr(through_table, self.field.forward_key) == instance_to_remove.id
                 & getattr(through_table, self.field.backward_key) == self.instance.id
             )
-        query = db.query_class.from_(through_table).where(
-            condition
-        ).delete()
+        query = db.query_class.from_(through_table).where(condition).delete()
         await db.execute_query(str(query))
 
 

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -47,21 +47,21 @@ def ends_with(field, value):
 
 
 def insensitive_contains(field, value):
-    return functions.Upper(
-        functions.Cast(field, SqlTypes.VARCHAR)
-    ).like(functions.Upper('%{}%'.format(value)))
+    return functions.Upper(functions.Cast(field, SqlTypes.VARCHAR)).like(
+        functions.Upper('%{}%'.format(value))
+    )
 
 
 def insensitive_starts_with(field, value):
-    return functions.Upper(
-        functions.Cast(field, SqlTypes.VARCHAR)
-    ).like(functions.Upper('{}%'.format(value)))
+    return functions.Upper(functions.Cast(field, SqlTypes.VARCHAR)).like(
+        functions.Upper('{}%'.format(value))
+    )
 
 
 def insensitive_ends_with(field, value):
-    return functions.Upper(
-        functions.Cast(field, SqlTypes.VARCHAR)
-    ).like(functions.Upper('%{}'.format(value)))
+    return functions.Upper(functions.Cast(field, SqlTypes.VARCHAR)).like(
+        functions.Upper('%{}'.format(value))
+    )
 
 
 def get_m2m_filters(field_name, field):
@@ -241,28 +241,33 @@ class ModelMeta(type):
                         null=value.null,
                         default=value.default,
                     )
-                    filters.update(get_filters_for_field(
-                        field_name=key_field,
-                        field=fields_map[key_field],
-                        source_field=key_field,
-                    ))
+                    filters.update(
+                        get_filters_for_field(
+                            field_name=key_field,
+                            field=fields_map[key_field],
+                            source_field=key_field,
+                        )
+                    )
                     fk_fields.add(key)
                 elif isinstance(value, fields.ManyToManyField):
                     m2m_fields.add(key)
                 else:
                     fields_db_projection[key] = value.source_field if value.source_field else key
-                    filters.update(get_filters_for_field(
-                        field_name=key,
-                        field=fields_map[key],
-                        source_field=fields_db_projection[key]
-                    ))
+                    filters.update(
+                        get_filters_for_field(
+                            field_name=key,
+                            field=fields_map[key],
+                            source_field=fields_db_projection[key]
+                        )
+                    )
         new_class = super().__new__(mcs, name, bases, attrs)
 
         new_class._meta = meta
         new_class._meta.fields_map = fields_map
         new_class._meta.fields_db_projection = fields_db_projection
         new_class._meta.fields_db_projection_reverse = {
-            value: key for key, value in fields_db_projection.items()
+            value: key
+            for key, value in fields_db_projection.items()
         }
         new_class._meta.fields = set(fields_map.keys())
         new_class._meta.db_fields = set(fields_db_projection.values())
@@ -286,7 +291,10 @@ class Model(metaclass=ModelMeta):
 
         for key, field in self._meta.fields_map.items():
             if isinstance(field, fields.BackwardFKRelation):
-                setattr(self, key, RelationQueryContainer(field.type, field.relation_field, self, is_new))
+                setattr(
+                    self, key,
+                    RelationQueryContainer(field.type, field.relation_field, self, is_new)
+                )
             elif isinstance(field, fields.ManyToManyField):
                 setattr(self, key, ManyToManyRelationManager(field.type, self, field, is_new))
             elif isinstance(field, fields.Field):
@@ -371,10 +379,7 @@ class Model(metaclass=ModelMeta):
         return self.__class__.__name__
 
     def __repr__(self):
-        return '<{}: {}>'.format(
-            self.__class__.__name__,
-            self.__str__()
-        )
+        return '<{}: {}>'.format(self.__class__.__name__, self.__str__())
 
     def __hash__(self):
         if not hasattr(self.id) or not self.id:

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ deps =
 [flake8]
 max-line-length = 100
 exclude =
-ignore =
+ignore = W503,E126


### PR DESCRIPTION
Fixed imports: (sort order, and unused. Exception is tortoise/__init__.py where I left imports)
Fixed flake8 issues, set up a custom yapf config to try and get the best auto formatting.
Fixed mypy issue.
Disabled pylint until we have a plugin else I would have to disable too much for it to be useful.
`make lint` still reports on all pylint stuff.

I added a `make style` command that wil run `yapf` and `isort` to automatically format. (not sure about the wisdom of this)