### PR TITLE
PyLint plugin

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,14 +15,14 @@ ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+init-hook='import sys; sys.path.append(".")'
 
 # Use multiple processes to speed up Pylint.
 jobs=0
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=pylint.extensions.bad_builtin
+load-plugins=pylint.extensions.bad_builtin,tortoise.pylint
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -56,7 +56,7 @@ confidence=
 # --disable=W"
 disable=C0301,C0330,C0412,C0411,
         W0613,W0212,
-        R,C0111, # tune down
+        R, # tune down
         print-statement,
         parameter-unpacking,
         unpacking-in-except,
@@ -357,7 +357,9 @@ good-names=i,
            ex,
            Run,
            _,
-	   id
+	   id,
+	   db,
+	   pk
 
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ deps:
 check: deps
 	flake8 $(checkfiles)
 	mypy $(mypy_flags) $(checkfiles)
+	pylint -E $(checkfiles)
 	python setup.py check -mrs
 
 lint: deps

--- a/docs/static_analysis.rst
+++ b/docs/static_analysis.rst
@@ -1,0 +1,18 @@
+===============
+Static Analysis
+===============
+
+PyLint Plugin
+=============
+
+Since Tortoise uses MetaClasses to build the Model objects, PyLint will often not understand how the Models behave. We provided a `tortoise.pylint` plugin that enhances PyLints understanding of Models and Fields.
+
+Usage
+-----
+
+In your projects ``.pylintrc`` file, ensure the following is set:
+
+.. code-block:: ini
+
+    load-plugins=tortoise.pylint
+

--- a/docs/toc.rst
+++ b/docs/toc.rst
@@ -8,4 +8,5 @@ Table Of Contents
    getting_started
    models_and_fields
    query
+   static_analysis
    CHANGELOG

--- a/tortoise/aggregation.py
+++ b/tortoise/aggregation.py
@@ -4,10 +4,11 @@ from pypika.functions import Count as PypikaCount
 from pypika.functions import Max as PypikaMax
 from pypika.functions import Min as PypikaMin
 from pypika.functions import Sum as PypikaSum
+from pypika.terms import AggregateFunction
 
 
 class Aggregate:
-    aggregation_func = None
+    aggregation_func = AggregateFunction
 
     def __init__(self, field):
         self.field = field

--- a/tortoise/models.py
+++ b/tortoise/models.py
@@ -387,6 +387,7 @@ class Model(metaclass=ModelMeta):
         return hash(self.id)
 
     def __eq__(self, other):
+        # pylint: disable=C0123
         if type(self) == type(other) and self.id == other.id:
             return True
         return False

--- a/tortoise/pylint/__init__.py
+++ b/tortoise/pylint/__init__.py
@@ -1,0 +1,120 @@
+'''
+Tortoise PyLint plugin
+'''
+import astroid
+from astroid import MANAGER, inference_tip, nodes, scoped_nodes
+from astroid.node_classes import Assign
+
+MODELS = {}  # type: dict
+FUTURE_RELATIONS = {}  # type: dict
+
+
+def register(linter):
+    '''
+    Reset state every time this is called, since we now get new AST to transform.
+    '''
+    # pylint: disable=W0603
+    global MODELS
+    global FUTURE_RELATIONS
+    MODELS = {}
+    FUTURE_RELATIONS = {}
+
+
+def is_model(cls):
+    '''
+    Guard to apply this transform to Models only
+    '''
+    return cls.metaclass() and cls.metaclass().qname() == 'tortoise.models.ModelMeta'
+
+
+def transform_model(cls):
+    '''
+    Anything that uses the ModelMeta needs _meta and id.
+    Also keep track of relationships and make them in the related model class.
+    '''
+    if cls.name != 'Model':
+        mname = 'models.%s' % (cls.name, )
+        MODELS[mname] = cls
+
+        for relname, relval in FUTURE_RELATIONS.get(mname, []):
+            cls.locals[relname] = relval
+
+        for attr in cls.get_children():
+            if isinstance(attr, Assign):
+                try:
+                    attrname = attr.value.func.attrname
+                except AttributeError:
+                    pass
+                else:
+                    if attrname in ['ForeignKeyField', 'ManyToManyField']:
+                        tomodel = attr.value.args[0].value
+                        relname = ''
+                        for keyword in attr.value.keywords:
+                            if keyword.arg == 'related_name':
+                                relname = keyword.value.value
+
+                        if relname:
+                            # Injected model attributes need to also have the relation manager
+                            if attrname == 'ManyToManyField':
+                                relval = [
+                                    attr.value.func,
+                                    MANAGER.ast_from_module_name('tortoise.fields')
+                                    .lookup('ManyToManyRelationManager')[1][0]
+                                ]
+                            else:
+                                relval = [
+                                    attr.value.func,
+                                    MANAGER.ast_from_module_name('tortoise.fields')
+                                    .lookup('RelationQueryContainer')[1][0]
+                                ]
+
+                            if tomodel in MODELS:
+                                MODELS[tomodel].locals[relname] = relval
+                            else:
+                                FUTURE_RELATIONS.setdefault(tomodel, []).append((relname, relval))
+
+    cls.locals['_meta'] = [
+        MANAGER.ast_from_module_name('tortoise.models').lookup('MetaInfo')[1][0].instantiate_class()
+    ]
+    if 'id' not in cls.locals:
+        cls.locals['id'] = [astroid.Class('id', None)]
+
+
+def is_model_field(cls):
+    '''
+    Guard to apply this transform to Model Fields only
+    '''
+    return cls.qname().startswith('tortoise.fields')
+
+
+def apply_type_shim(cls, _context=None):
+    '''
+    Morphs model fields to representative type
+    '''
+    if cls.name in ['IntField', 'SmallIntField']:
+        base_nodes = scoped_nodes.builtin_lookup('int')
+    elif cls.name in ['CharField', 'TextField']:
+        base_nodes = scoped_nodes.builtin_lookup('str')
+    elif cls.name == 'BooleanField':
+        base_nodes = scoped_nodes.builtin_lookup('bool')
+    elif cls.name == 'FloatField':
+        base_nodes = scoped_nodes.builtin_lookup('float')
+    elif cls.name == 'DecimalField':
+        base_nodes = MANAGER.ast_from_module_name('decimal').lookup('Decimal')
+    elif cls.name == 'DatetimeField':
+        base_nodes = MANAGER.ast_from_module_name('datetime').lookup('datetime')
+    elif cls.name == 'DateField':
+        base_nodes = MANAGER.ast_from_module_name('datetime').lookup('date')
+    elif cls.name == 'ForeignKeyField':
+        base_nodes = MANAGER.ast_from_module_name('tortoise.fields').lookup('BackwardFKRelation')
+    elif cls.name == 'ManyToManyField':
+        base_nodes = MANAGER.ast_from_module_name('tortoise.fields'
+                                                  ).lookup('ManyToManyRelationManager')
+    else:
+        return iter([cls])
+
+    return iter([cls] + base_nodes[1])
+
+
+MANAGER.register_transform(nodes.Class, inference_tip(apply_type_shim), is_model_field)
+MANAGER.register_transform(astroid.Class, transform_model, is_model)

--- a/tortoise/query_utils.py
+++ b/tortoise/query_utils.py
@@ -3,7 +3,7 @@ from pypika import Table
 from tortoise import fields
 
 
-class Q:
+class Q:  # pylint: disable=C0103
     AND = 'AND'
     OR = 'OR'
 

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -321,7 +321,7 @@ class QuerySet(AwaitableQuery):
                 continue
             relation_split = relation.split('__')
             first_level_field = relation_split[0]
-            if not (first_level_field in self.model._meta.fetch_fields):
+            if first_level_field not in self.model._meta.fetch_fields:
                 raise FieldError(
                     'relation {} for {} not found'.format(
                         first_level_field, self.model._meta.table


### PR DESCRIPTION
My first PyLint plugin, it was easier than I expected (but also quite fiddly, I used `pylint-django` as a reference, as the `Astroid` docs was sorely lacking)

The `tortoise.pylint` module now contains two AST transforms for:
* Models → `_meta`, `id` and `related_name` of relationships on remote model.
* Fields on Models → Transforms the type to ALSO be the instantiated python typ.

This fixes nearly every case of PyLint not finding an attribute, or the attribute not following through.
+
Made `Aggregate.aggregate_function` point to `pypika.terms.AggregateFunction` instead of None, as the astract class will never be called, and this resolves issues on Aggregates.
A few other small/safe changes. (not error related)

I re-enabled `pylint -E` as part of `make check` as all "errors" are now fixed.

I also added the PyLint plugin and usage of it to the docs.