### PR TITLE
Added Python 3.7 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.9.3
+-----
+- Fixed backward incompatibility for Python 3.7
+
 0.9.2
 -----
 - ``JSONField`` is now promoted to a standard field.

--- a/tortoise/__init__.py
+++ b/tortoise/__init__.py
@@ -147,4 +147,4 @@ class Tortoise:
         cls._inited = True
 
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -8,7 +8,7 @@ from tortoise.aggregation import Aggregate
 from tortoise.backends.base.client import BaseDBAsyncClient
 from tortoise.exceptions import FieldError
 from tortoise.query_utils import Prefetch, Q
-from tortoise.utils import AsyncIteratorWrapper
+from tortoise.utils import QueryAsyncIterator
 
 
 class AwaitableQuery:
@@ -403,9 +403,8 @@ class QuerySet(AwaitableQuery):
             return instance_list[0]
         return instance_list
 
-    async def __aiter__(self):
-        result = await self
-        return AsyncIteratorWrapper(result)
+    def __aiter__(self):
+        return QueryAsyncIterator(self)
 
 
 class UpdateQuery(AwaitableQuery):


### PR DESCRIPTION
Resolves #21 
I managed to fix problem, even though it turned to be quite hacky to keep it working the way it was. Problem seemed to be because they changed prohibited behaviour for `__aiter__` in 3.7.
I think we will wait for pylint 2.0 to come out before adding 3.7 into CI pipeline, but tortoise itself should work fine on 3.7