### PR TITLE
Replaced all asserts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,14 @@ check: deps
 	flake8 $(checkfiles)
 	mypy $(mypy_flags) $(checkfiles)
 	pylint -E $(checkfiles)
+	bandit -r $(checkfiles)
 	python setup.py check -mrs
 
 lint: deps
 	-flake8 $(checkfiles)
 	-mypy $(mypy_flags) $(checkfiles)
 	-pylint $(checkfiles)
+	-bandit -r $(checkfiles)
 	-python setup.py check -mrs
 
 test: deps

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,11 @@
 Tortoise
 ========
 
+.. image:: https://travis-ci.com/Zeliboba5/tortoise-orm.svg?branch=master
+    :target: https://travis-ci.com/Zeliboba5/tortoise-orm
+.. image:: https://coveralls.io/repos/github/Zeliboba5/tortoise-orm/badge.svg?branch=master
+    :target: https://coveralls.io/github/Zeliboba5/tortoise-orm?branch=master
+
 Introduction
 ============
 Tortoise is easy-to-use asyncio ORM inspired by Django.

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,7 +1,0 @@
-import uuid
-
-
-def get_db_name():
-    db_id = uuid.uuid4().hex
-    name = '/tmp/test-{}.sqlite'.format(db_id)
-    return name

--- a/examples/aggregation.py
+++ b/examples/aggregation.py
@@ -57,21 +57,21 @@ async def run():
     await event.participants.add(participants[0], participants[1])
     await event.participants.add(participants[0], participants[1])
 
-    tournaments_with_count = await Tournament.all().annotate(
+    print(await Tournament.all().annotate(
         events_count=Count('events'),
-    ).filter(events_count__gte=1)
+    ).filter(events_count__gte=1))
 
-    event_with_lowest_team_id = await Event.filter(id=event.id).first().annotate(
+    print(await Event.filter(id=event.id).first().annotate(
         lowest_team_id=Min('participants__id')
-    )
+    ))
 
-    ordered_tournaments = await Tournament.all().annotate(
+    print(await Tournament.all().annotate(
         events_count=Count('events'),
-    ).order_by('events_count')
+    ).order_by('events_count'))
 
-    event_with_annotation = await Event.all().annotate(
+    print(await Event.all().annotate(
         tournament_test_id=Sum('tournament__id'),
-    ).first()
+    ).first())
 
 
 if __name__ == '__main__':

--- a/examples/aggregation.py
+++ b/examples/aggregation.py
@@ -1,6 +1,5 @@
 import asyncio
 
-from examples import get_db_name
 from tortoise import Tortoise, fields
 from tortoise.aggregation import Count, Min, Sum
 from tortoise.backends.sqlite.client import SqliteClient
@@ -39,8 +38,7 @@ class Team(Model):
 
 
 async def run():
-    db_name = get_db_name()
-    client = SqliteClient(db_name)
+    client = SqliteClient('example_aggregation.sqlite3')
     await client.create_connection()
     Tortoise.init(client)
     await generate_schema(client)
@@ -62,21 +60,18 @@ async def run():
     tournaments_with_count = await Tournament.all().annotate(
         events_count=Count('events'),
     ).filter(events_count__gte=1)
-    assert len(tournaments_with_count) == 1 and tournaments_with_count[0].events_count == 2
 
     event_with_lowest_team_id = await Event.filter(id=event.id).first().annotate(
         lowest_team_id=Min('participants__id')
     )
-    assert event_with_lowest_team_id.lowest_team_id == participants[0].id
 
     ordered_tournaments = await Tournament.all().annotate(
         events_count=Count('events'),
     ).order_by('events_count')
-    assert len(ordered_tournaments) == 2 and ordered_tournaments[1].id == tournament.id
+
     event_with_annotation = await Event.all().annotate(
         tournament_test_id=Sum('tournament__id'),
     ).first()
-    assert event_with_annotation.tournament_test_id == event_with_annotation.tournament_id
 
 
 if __name__ == '__main__':

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -3,7 +3,6 @@ This example demonstrates most basic operations with single model
 """
 import asyncio
 
-from examples import get_db_name
 from tortoise import Tortoise, fields
 from tortoise.backends.sqlite.client import SqliteClient
 from tortoise.models import Model
@@ -23,15 +22,16 @@ class Event(Model):
 
 
 async def run():
-    db_name = get_db_name()
-    client = SqliteClient(db_name)
+    client = SqliteClient('example_basic.sqlite3')
     await client.create_connection()
     Tortoise.init(client)
+
     await generate_schema(client)
+
     event = await Event.create(name='Test')
     await Event.filter(id=event.id).update(name='Updated name')
     saved_event = await Event.filter(name='Updated name').first()
-    assert saved_event.id == event.id
+
     await Event(name='Test 2').save()
     await Event.all().values_list('id', flat=True)
     await Event.all().values('id', 'name')

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -30,11 +30,12 @@ async def run():
 
     event = await Event.create(name='Test')
     await Event.filter(id=event.id).update(name='Updated name')
-    saved_event = await Event.filter(name='Updated name').first()
+
+    print(await Event.filter(name='Updated name').first())
 
     await Event(name='Test 2').save()
-    await Event.all().values_list('id', flat=True)
-    await Event.all().values('id', 'name')
+    print(await Event.all().values_list('id', flat=True))
+    print(await Event.all().values('id', 'name'))
 
 
 if __name__ == '__main__':

--- a/examples/complex_filtering.py
+++ b/examples/complex_filtering.py
@@ -69,19 +69,20 @@ async def run():
     await team_first.events.add(event_first)
     await event_second.participants.add(team_second)
 
-    found_events = await Event.filter(Q(id__in=[event_first.id, event_second.id])
-                                      | Q(name='3')).filter(participants__not=team_second.id
-                                                            ).order_by('tournament__id').distinct()
+    print(await Event.filter(
+        Q(id__in=[event_first.id, event_second.id])
+        | Q(name='3')).filter(
+            participants__not=team_second.id).order_by('tournament__id').distinct())
 
-    await Team.filter(events__tournament_id=tournament.id).order_by('-events__name')
-    await Tournament.filter(
+    print(await Team.filter(events__tournament_id=tournament.id).order_by('-events__name'))
+    print(await Tournament.filter(
         events__name__in=['1', '3'],
-    ).order_by('-events__participants__name').distinct()
+    ).order_by('-events__participants__name').distinct())
 
-    teams = await Team.filter(name__icontains='CON')
+    print(await Team.filter(name__icontains='CON'))
 
-    tournaments = await Tournament.filter(events__participants__name__startswith='Fir')
-    await Tournament.filter(id__icontains=1).count()
+    print(await Tournament.filter(events__participants__name__startswith='Fir'))
+    print(await Tournament.filter(id__icontains=1).count())
 
 
 if __name__ == '__main__':

--- a/examples/complex_filtering.py
+++ b/examples/complex_filtering.py
@@ -5,7 +5,6 @@ Key points are filtering by related names and using Q objects
 """
 import asyncio
 
-from examples import get_db_name
 from tortoise import Tortoise, fields
 from tortoise.backends.sqlite.client import SqliteClient
 from tortoise.models import Model
@@ -42,8 +41,7 @@ class Team(Model):
 
 
 async def run():
-    db_name = get_db_name()
-    client = SqliteClient(db_name)
+    client = SqliteClient('example_filtering.sqlite3')
     await client.create_connection()
     Tortoise.init(client)
     await generate_schema(client)
@@ -74,19 +72,16 @@ async def run():
     found_events = await Event.filter(Q(id__in=[event_first.id, event_second.id])
                                       | Q(name='3')).filter(participants__not=team_second.id
                                                             ).order_by('tournament__id').distinct()
-    assert len(found_events) == 2
-    assert found_events[0].id == event_first.id and found_events[1].id == event_third.id
+
     await Team.filter(events__tournament_id=tournament.id).order_by('-events__name')
     await Tournament.filter(
         events__name__in=['1', '3'],
     ).order_by('-events__participants__name').distinct()
 
     teams = await Team.filter(name__icontains='CON')
-    assert len(teams) == 1 and teams[0].name == 'Second'
 
     tournaments = await Tournament.filter(events__participants__name__startswith='Fir')
-    assert len(tournaments) == 1 and tournaments[0] == tournament
-    assert await Tournament.filter(id__icontains=1).count() == 1
+    await Tournament.filter(id__icontains=1).count()
 
 
 if __name__ == '__main__':

--- a/examples/complex_prefetching.py
+++ b/examples/complex_prefetching.py
@@ -1,6 +1,5 @@
 import asyncio
 
-from examples import get_db_name
 from tortoise import Tortoise, fields
 from tortoise.backends.sqlite.client import SqliteClient
 from tortoise.models import Model
@@ -37,8 +36,7 @@ class Team(Model):
 
 
 async def run():
-    db_name = get_db_name()
-    client = SqliteClient(db_name)
+    client = SqliteClient('example_prefetching.sqlite3')
     await client.create_connection()
     Tortoise.init(client)
     await generate_schema(client)
@@ -50,8 +48,6 @@ async def run():
         Prefetch('events', queryset=Event.filter(name='First'))
     ).first()
     tournament = await Tournament.first().prefetch_related('events')
-    assert len(tournament_with_filtered.events) == 1
-    assert len(tournament.events) == 2
 
 
 if __name__ == '__main__':

--- a/examples/complex_prefetching.py
+++ b/examples/complex_prefetching.py
@@ -47,7 +47,8 @@ async def run():
     tournament_with_filtered = await Tournament.all().prefetch_related(
         Prefetch('events', queryset=Event.filter(name='First'))
     ).first()
-    tournament = await Tournament.first().prefetch_related('events')
+    print(tournament_with_filtered)
+    print(await Tournament.first().prefetch_related('events'))
 
 
 if __name__ == '__main__':

--- a/examples/postgres.py
+++ b/examples/postgres.py
@@ -53,8 +53,8 @@ async def run():
     report_data = {
         'foo': 'bar',
     }
-    report = await Report.create(content=report_data)
-    result = await Report.filter(content=report_data).first()
+    print(await Report.create(content=report_data))
+    print(await Report.filter(content=report_data).first())
 
 
 if __name__ == '__main__':

--- a/examples/postgres.py
+++ b/examples/postgres.py
@@ -55,8 +55,6 @@ async def run():
     }
     report = await Report.create(content=report_data)
     result = await Report.filter(content=report_data).first()
-    assert result.id == report.id
-    assert result.content == report_data
 
 
 if __name__ == '__main__':

--- a/examples/relations.py
+++ b/examples/relations.py
@@ -73,25 +73,24 @@ async def run():
     for team in event.participants:
         print(team.id)
 
-
-    selected_events = await Event.filter(
+    print(await Event.filter(
         participants=participants[0].id,
-    ).prefetch_related('participants', 'tournament')
-    await participants[0].fetch_related('events')
+    ).prefetch_related('participants', 'tournament'))
+    print(await participants[0].fetch_related('events'))
 
-    await Team.fetch_for_list(participants, 'events')
+    print(await Team.fetch_for_list(participants, 'events'))
 
-    await Team.filter(events__tournament__id=tournament.id)
+    print(await Team.filter(events__tournament__id=tournament.id))
 
-    await Event.filter(tournament=tournament)
+    print(await Event.filter(tournament=tournament))
 
-    await Tournament.filter(
+    print(await Tournament.filter(
         events__name__in=['Test', 'Prod'],
-    ).order_by('-events__participants__name').distinct()
+    ).order_by('-events__participants__name').distinct())
 
-    result = await Event.filter(id=event.id).values('id', 'name', tournament='tournament__name')
+    print(await Event.filter(id=event.id).values('id', 'name', tournament='tournament__name'))
 
-    result = await Event.filter(id=event.id).values_list('id', 'participants__name')
+    print(await Event.filter(id=event.id).values_list('id', 'participants__name'))
 
 
 if __name__ == '__main__':

--- a/examples/schema_create.py
+++ b/examples/schema_create.py
@@ -1,6 +1,5 @@
 import asyncio
 import binascii
-import datetime
 import os
 
 from tortoise import Tortoise, fields
@@ -54,11 +53,13 @@ async def run():
     tournament = await Tournament.create(name='Test')
 
     event = await Event.create(name='Test 1', tournament=tournament, prize=100)
-    old_time = event.modified
+    print(event.modified)
     event.name = 'Test 2'
     await event.save()
+    print(event.modified)
+
     await Team.create(name='test')
-    result = await Team.all().values('name')
+    print(await Team.all().values('name'))
 
 
 if __name__ == '__main__':

--- a/examples/schema_create.py
+++ b/examples/schema_create.py
@@ -3,7 +3,6 @@ import binascii
 import datetime
 import os
 
-from examples import get_db_name
 from tortoise import Tortoise, fields
 from tortoise.backends.sqlite.client import SqliteClient
 from tortoise.models import Model
@@ -47,24 +46,19 @@ class Team(Model):
 
 
 async def run():
-    db_name = get_db_name()
-    client = SqliteClient(db_name)
+    client = SqliteClient('example_schema.sqlite3')
     await client.create_connection()
     Tortoise.init(client)
     await generate_schema(client)
 
     tournament = await Tournament.create(name='Test')
-    assert tournament.created and tournament.created.date() == datetime.date.today()
 
     event = await Event.create(name='Test 1', tournament=tournament, prize=100)
     old_time = event.modified
     event.name = 'Test 2'
     await event.save()
-    assert event.modified > old_time
-    assert len(event.token) == 32
     await Team.create(name='test')
     result = await Team.all().values('name')
-    assert result[0]['name'] == 'test'
 
 
 if __name__ == '__main__':

--- a/examples/transactions.py
+++ b/examples/transactions.py
@@ -8,7 +8,6 @@ you could still do it like this
 import asyncio
 import sqlite3
 
-from examples import get_db_name
 from tortoise import Tortoise, fields
 from tortoise.backends.sqlite.client import SqliteClient
 from tortoise.models import Model
@@ -27,8 +26,7 @@ class Event(Model):
 
 
 async def run():
-    db_name = get_db_name()
-    client = SqliteClient(db_name)
+    client = SqliteClient('example_transaction.sqlite3')
     await client.create_connection()
     Tortoise.init(client)
     await generate_schema(client)
@@ -39,12 +37,11 @@ async def run():
             await event.save(using_db=connection)
             await Event.filter(id=event.id).using_db(connection).update(name='Updated name')
             saved_event = await Event.filter(name='Updated name').using_db(connection).first()
-            assert saved_event.id == event.id
             await connection.execute_query('SELECT * FROM non_existent_table')
     except sqlite3.OperationalError:
         pass
     saved_event = await Event.filter(name='Updated name').first()
-    assert not saved_event
+    print(saved_event)
 
 
 if __name__ == '__main__':

--- a/examples/two_databases.py
+++ b/examples/two_databases.py
@@ -11,7 +11,6 @@ and explicitly declaring model apps in class Meta
 import asyncio
 from sqlite3 import OperationalError
 
-from examples import get_db_name
 from tortoise import Tortoise, fields
 from tortoise.backends.sqlite.client import SqliteClient
 from tortoise.models import Model
@@ -57,10 +56,8 @@ class Team(Model):
 
 
 async def run():
-    db_name = get_db_name()
-    second_db_name = get_db_name()
-    client = SqliteClient(db_name)
-    second_client = SqliteClient(second_db_name)
+    client = SqliteClient('example_2db_first.sqlite3')
+    second_client = SqliteClient('example_2db_second.sqlite3')
     await client.create_connection()
     await second_client.create_connection()
     Tortoise.init(db_routing={
@@ -75,11 +72,10 @@ async def run():
 
     try:
         await client.execute_query('SELECT * FROM "event"')
-        assert False
     except OperationalError:
-        pass
+        print('Expected it to fail')
     results = await second_client.execute_query('SELECT * FROM "event"')
-    assert results
+    print(results)
 
 
 if __name__ == '__main__':

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -21,6 +21,7 @@ pylint
 docutils
 pygments
 yapf
+bandit
 
 ## Test tools
 tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ astroid==1.6.5            # via pylint
 asyncpg==0.16.0
 asynctest==0.12.2
 babel==2.6.0              # via sphinx
+bandit==1.4.0
 certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
 ciso8601==2.0.1
@@ -24,6 +25,8 @@ docutils==0.14
 first==2.0.1              # via pip-tools
 flake8-isort==2.5
 flake8==3.5.0             # via flake8-isort
+gitdb2==2.0.3             # via gitpython
+gitpython==2.1.10         # via bandit
 green==2.12.1
 idna==2.7                 # via requests
 imagesize==1.0.0          # via sphinx
@@ -33,7 +36,8 @@ lazy-object-proxy==1.3.1  # via astroid
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8, pylint
 mypy==0.610
-packaging==17.1           # via sphinx
+packaging==17.1           # via sphinx, tox
+pbr==4.1.0                # via stevedore
 pip-tools==2.0.2
 pluggy==0.6.0             # via tox
 py==1.5.4                 # via tox
@@ -42,16 +46,19 @@ pyflakes==1.6.0           # via flake8
 pygments==2.2.0
 pylint==1.9.2
 pyparsing==2.2.0          # via packaging
-pypika==0.14.5
+pypika==0.14.8
 pytz==2018.5              # via babel
+pyyaml==3.13              # via bandit
 requests==2.19.1          # via coveralls, sphinx
-six==1.11.0               # via astroid, packaging, pip-tools, pylint, sphinx, tox
+six==1.11.0               # via astroid, bandit, packaging, pip-tools, pylint, sphinx, stevedore, tox
+smmap2==2.0.3             # via gitdb2
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.7.5
 sphinxcontrib-websupport==1.1.0  # via sphinx
+stevedore==1.28.0         # via bandit
 termstyle==0.1.11         # via green
 testfixtures==6.2.0       # via flake8-isort
-tox==3.0.0
+tox==3.1.0
 typed-ast==1.1.0          # via mypy
 unidecode==1.0.22         # via green
 urllib3==1.23             # via requests

--- a/tortoise/aggregation.py
+++ b/tortoise/aggregation.py
@@ -6,6 +6,8 @@ from pypika.functions import Min as PypikaMin
 from pypika.functions import Sum as PypikaSum
 from pypika.terms import AggregateFunction
 
+from tortoise.exceptions import ConfigurationError
+
 
 class Aggregate:
     aggregation_func = AggregateFunction
@@ -33,7 +35,8 @@ class Aggregate:
                 )
             return aggregation
         else:
-            assert field_split[0] in model._meta.fetch_fields
+            if field_split[0] not in model._meta.fetch_fields:
+                raise ConfigurationError('{} not resolvable'.format(field))
             related_field = model._meta.fields_map[field_split[0]]
             join = (Table(model._meta.table), field_split[0], related_field)
             aggregation = self._resolve_field_for_model(

--- a/tortoise/backends/asyncpg/client.py
+++ b/tortoise/backends/asyncpg/client.py
@@ -7,7 +7,7 @@ from tortoise.backends.asyncpg.executor import AsyncpgExecutor
 from tortoise.backends.asyncpg.schema_generator import AsyncpgSchemaGenerator
 from tortoise.backends.base.client import (BaseDBAsyncClient, ConnectionWrapper,
                                            SingleConnectionWrapper)
-from tortoise.exceptions import IntegrityError, OperationalError
+from tortoise.exceptions import ConfigurationError, IntegrityError, OperationalError
 
 
 class AsyncpgDBClient(BaseDBAsyncClient):
@@ -131,7 +131,8 @@ class AsyncpgDBClient(BaseDBAsyncClient):
 
 class TransactionWrapper(AsyncpgDBClient):
     def __init__(self, pool=None, connection=None):
-        assert bool(pool) != bool(connection), 'You must pass either connection or pool'
+        if pool and connection:
+            raise ConfigurationError('You must pass either connection or pool')
         self._connection = connection
         self.log = logging.getLogger('db_client')
         self._pool = pool

--- a/tortoise/backends/base/executor.py
+++ b/tortoise/backends/base/executor.py
@@ -3,6 +3,7 @@ import datetime
 from pypika import Table
 
 from tortoise import fields
+from tortoise.exceptions import OperationalError
 
 
 class BaseExecutor:
@@ -205,9 +206,9 @@ class BaseExecutor:
         for relation in args:
             relation_split = relation.split('__')
             first_level_field = relation_split[0]
-            assert (
-                first_level_field in self.model._meta.fetch_fields
-            ), 'relation {} for {} not found'.format(first_level_field, self.model._meta.table)
+            if first_level_field not in self.model._meta.fetch_fields:
+                raise OperationalError('relation {} for {} not found'.format(
+                    first_level_field, self.model._meta.table))
             if first_level_field not in self.prefetch_map.keys():
                 self.prefetch_map[first_level_field] = set()
             forwarded_prefetch = '__'.join(relation_split[1:])

--- a/tortoise/exceptions.py
+++ b/tortoise/exceptions.py
@@ -23,9 +23,9 @@ class OperationalError(BaseORMException):
     pass
 
 
-class ConfigurationError(Exception):
+class ConfigurationError(BaseORMException):
     pass
 
 
-class IntegrityError(Exception):
+class IntegrityError(BaseORMException):
     pass

--- a/tortoise/queryset.py
+++ b/tortoise/queryset.py
@@ -6,7 +6,7 @@ from pypika.functions import Count
 from tortoise import fields
 from tortoise.aggregation import Aggregate
 from tortoise.backends.base.client import BaseDBAsyncClient
-from tortoise.exceptions import FieldError
+from tortoise.exceptions import FieldError, OperationalError
 from tortoise.query_utils import Prefetch, Q
 from tortoise.utils import QueryAsyncIterator
 
@@ -429,7 +429,8 @@ class UpdateQuery(AwaitableQuery):
             field_object = model._meta.fields_map.get(key)
             if not field_object:
                 raise FieldError('Unknown keyword argument {} for model {}'.format(key, model))
-            assert not field_object.generated, 'Field {} is generated and can not be updated'
+            if field_object.generated:
+                raise OperationalError('Field {} is generated and can not be updated')
             if isinstance(field_object, fields.ForeignKeyField):
                 db_field = '{}_id'.format(key)
                 value = value.id


### PR DESCRIPTION
I replaced all `assert` and `AssertionError` with either a `tortoise.exceptions.OperationalError` or `tortoise.exceptions.ConfigurationErrer` as I saw the best match.

I also added https://github.com/PyCQA/bandit as a static analysis tool, to try limit the stupid security issues.

I had to change the examples that now don't have asserts to print instead.