### PR TITLE
Fix ReadTheDocs to build using Python3.6 and install dependancies for autodoc

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,6 @@
+build:
+  image: latest
+
+python:
+  version: 3.6
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+-r ../requirements.txt
+
 sphinx
 cloud_sptheme
 


### PR DESCRIPTION
It seems that RTD uses Python2.7 by default, so autodoc failed with syntax errors.
This tells RTD to use Py3.6, and to also install our standard runtime dependencies so that we don't get import errors.

This is a best effort, so I hope it solves all the problems.