### PR TITLE
Add mocks of optional libraries for autodoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,16 @@ import sys
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('..'))
 
+from unittest.mock import MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return MagicMock()
+
+MOCK_MODULES = ['aiosqlite', 'astroid', 'asyncpg', 'asynctest', 'aiomysql']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
This should fix the last of the ReadTheDocs autodoc build errors.