### PR TITLE
New TestCase fixes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,9 @@
 branch = True
 source =
     tortoise
+omit =
+    tortoise/contrib/pylint/*
+    tortoise/tests/*
 [report]
 show_missing = True
 

--- a/.green
+++ b/.green
@@ -2,3 +2,5 @@ verbose       = 2
 omit-patterns = tortoise/contrib/pylint/*,tortoise/tests/*
 clear-omit    = true
 run-coverage  = true
+initializer   = tortoise.contrib.test.initializer
+finalizer     = tortoise.contrib.test.finalizer

--- a/.green
+++ b/.green
@@ -2,5 +2,6 @@ verbose       = 2
 omit-patterns = tortoise/contrib/pylint/*,tortoise/tests/*
 clear-omit    = true
 run-coverage  = true
+quiet-coverage= true
 initializer   = tortoise.contrib.test.initializer
 finalizer     = tortoise.contrib.test.finalizer

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ lint: deps
 
 test: deps
 	green
+	coverage run -a -m tortoise.tests.inittest
+	coverage report
 
 ci: check test
 

--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -21,9 +21,10 @@ Mark test as expecting failiure.
 On success it will be marked as unexpected success.
 """
 
-_CONFIG = {}
-_APPS = {}
-_CONNECTIONS = {}
+_CONFIG = {}  # type: dict
+_APPS = {}  # type: dict
+_CONNECTIONS = {}  # type: dict
+
 
 def getDBConfig(app_label: str, model_modules: List[str]) -> dict:
     """

--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -1,5 +1,6 @@
 import asyncio as _asyncio
 import os as _os
+from copy import deepcopy
 from typing import List
 from unittest import SkipTest, expectedFailure, skip, skipIf, skipUnless  # noqa
 
@@ -60,13 +61,13 @@ def initializer():
 
     loop = _asyncio.get_event_loop()
     loop.run_until_complete(_init_db(_CONFIG))
-    _APPS = Tortoise.apps.copy()
+    _APPS = deepcopy(Tortoise.apps)
     _CONNECTIONS = Tortoise._connections.copy()
     loop.run_until_complete(Tortoise._reset_connections())
 
 
 def finalizer():
-    Tortoise.apps = _APPS.copy()
+    Tortoise.apps = deepcopy(_APPS)
     Tortoise._connections = _CONNECTIONS.copy()
     loop = _asyncio.get_event_loop()
     loop.run_until_complete(Tortoise._drop_databases())
@@ -150,7 +151,7 @@ class TestCase(SimpleTestCase):
     """
 
     async def _setUpDB(self):
-        Tortoise.apps = _APPS.copy()
+        Tortoise.apps = deepcopy(_APPS)
         Tortoise._connections = _CONNECTIONS.copy()
         await Tortoise.init(_CONFIG)
 

--- a/tortoise/contrib/test/__init__.py
+++ b/tortoise/contrib/test/__init__.py
@@ -42,7 +42,7 @@ async def _init_db(config):
     try:
         await Tortoise.init(config)
         await Tortoise._drop_databases()
-    except DBConnectionError as exc:
+    except DBConnectionError as exc:  # pragma: nocoverage
         pass
 
     await Tortoise.init(config, _create_db=True)

--- a/tortoise/exceptions.py
+++ b/tortoise/exceptions.py
@@ -1,5 +1,6 @@
-__all__ = ('BaseORMException', 'FieldError', 'ConfigurationError', 'OperationalError',
-           'IntegrityError', 'NoValuesFetched', 'MultipleObjectsReturned', 'DoesNotExist')
+__all__ = ('BaseORMException', 'FieldError', 'ConfigurationError', 'TransactionManagementError',
+           'OperationalError', 'IntegrityError', 'NoValuesFetched', 'MultipleObjectsReturned',
+           'DoesNotExist')
 
 
 class BaseORMException(Exception):
@@ -26,6 +27,13 @@ class ParamsError(BaseORMException):
 class ConfigurationError(BaseORMException):
     """
     The ConfigurationError exception is raised when the configuration of the ORM is invalid.
+    """
+    pass
+
+
+class TransactionManagementError(BaseORMException):
+    """
+    The TransactionManagementError is raised when any transaction error occurs.
     """
     pass
 

--- a/tortoise/tests/inittest.py
+++ b/tortoise/tests/inittest.py
@@ -1,0 +1,7 @@
+"""
+Only for coverage of initialiser/finaliser portions of our tests
+"""
+from tortoise.contrib.test import finalizer, initializer
+
+initializer()
+finalizer()

--- a/tortoise/tests/test_fields.py
+++ b/tortoise/tests/test_fields.py
@@ -35,7 +35,7 @@ class TestFieldErrors(test.SimpleTestCase):
             fields.DatetimeField(auto_now=True, auto_now_add=True)
 
 
-class TestIntFields(test.IsolatedTestCase):
+class TestIntFields(test.TestCase):
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.IntFields.create()
@@ -65,7 +65,7 @@ class TestIntFields(test.IsolatedTestCase):
         self.assertEqual(values[0], 1)
 
 
-class TestSmallIntFields(test.IsolatedTestCase):
+class TestSmallIntFields(test.TestCase):
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.SmallIntFields.create()
@@ -91,7 +91,7 @@ class TestSmallIntFields(test.IsolatedTestCase):
         self.assertEqual(values[0], 2)
 
 
-class TestCharFields(test.IsolatedTestCase):
+class TestCharFields(test.TestCase):
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.CharFields.create()
@@ -121,7 +121,7 @@ class TestCharFields(test.IsolatedTestCase):
         self.assertEqual(values[0], 'moo')
 
 
-class TestTextFields(test.IsolatedTestCase):
+class TestTextFields(test.TestCase):
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.TextFields.create()
@@ -146,7 +146,7 @@ class TestTextFields(test.IsolatedTestCase):
         self.assertEqual(values[0], 'baa')
 
 
-class TestBooleanFields(test.IsolatedTestCase):
+class TestBooleanFields(test.TestCase):
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.BooleanFields.create()
@@ -171,7 +171,7 @@ class TestBooleanFields(test.IsolatedTestCase):
         self.assertEqual(values[0], True)
 
 
-class TestDecimalFields(test.IsolatedTestCase):
+class TestDecimalFields(test.TestCase):
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.DecimalFields.create()
@@ -199,7 +199,7 @@ class TestDecimalFields(test.IsolatedTestCase):
         self.assertEqual(list(values[0]), [Decimal('1.2346'), 19])
 
 
-class TestDatetimeFields(test.IsolatedTestCase):
+class TestDatetimeFields(test.TestCase):
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.DatetimeFields.create()
@@ -243,7 +243,7 @@ class TestDatetimeFields(test.IsolatedTestCase):
         self.assertEqual(values[0], now)
 
 
-class TestDateFields(test.IsolatedTestCase):
+class TestDateFields(test.TestCase):
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.DateFields.create()
@@ -277,7 +277,7 @@ class TestDateFields(test.IsolatedTestCase):
         self.assertEqual(values[0], today)
 
 
-class TestFloatFields(test.IsolatedTestCase):
+class TestFloatFields(test.TestCase):
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.FloatFields.create()
@@ -313,7 +313,7 @@ class TestFloatFields(test.IsolatedTestCase):
         self.assertEqual(list(values[0]), [1.23])
 
 
-class TestJSONFields(test.IsolatedTestCase):
+class TestJSONFields(test.TestCase):
     async def test_empty(self):
         with self.assertRaises(IntegrityError):
             await testmodels.JSONFields.create()

--- a/tortoise/tests/test_relations.py
+++ b/tortoise/tests/test_relations.py
@@ -22,9 +22,12 @@ class TestRelations(test.TestCase):
         teamids = []
         async for team in event.participants:
             teamids.append(team.id)
-        self.assertEqual(teamids, [1, 2])
+        self.assertEqual(teamids, [participants[0].id, participants[1].id])
 
-        self.assertEqual([team.id for team in event.participants], [1, 2])
+        self.assertEqual(
+            [team.id for team in event.participants],
+            [participants[0].id, participants[1].id]
+        )
 
         self.assertEqual(event.participants[0].id, participants[0].id)
 

--- a/tortoise/tests/test_transactions.py
+++ b/tortoise/tests/test_transactions.py
@@ -34,14 +34,11 @@ class TestTransactions(test.IsolatedTestCase):
             saved_event = await Tournament.filter(name='Updated name').first()
             self.assertEqual(saved_event.id, tournament.id)
             with self.assertRaises(SomeException):
-                try:
-                    async with in_transaction():
-                        tournament = await Tournament.create(name='Nested')
-                        saved_tournament = await Tournament.filter(name='Nested').first()
-                        self.assertEqual(tournament.id, saved_tournament.id)
-                        raise SomeException('Some error')
-                except TransactionManagementError:
-                    raise test.SkipTest('Nested transactions not supported by SQLite build')
+                async with in_transaction():
+                    tournament = await Tournament.create(name='Nested')
+                    saved_tournament = await Tournament.filter(name='Nested').first()
+                    self.assertEqual(tournament.id, saved_tournament.id)
+                    raise SomeException('Some error')
 
         saved_event = await Tournament.filter(name='Updated name').first()
         self.assertIsNotNone(saved_event)

--- a/tortoise/tests/test_transactions.py
+++ b/tortoise/tests/test_transactions.py
@@ -34,11 +34,14 @@ class TestTransactions(test.IsolatedTestCase):
             saved_event = await Tournament.filter(name='Updated name').first()
             self.assertEqual(saved_event.id, tournament.id)
             with self.assertRaises(SomeException):
-                async with in_transaction():
-                    tournament = await Tournament.create(name='Nested')
-                    saved_tournament = await Tournament.filter(name='Nested').first()
-                    self.assertEqual(tournament.id, saved_tournament.id)
-                    raise SomeException('Some error')
+                try:
+                    async with in_transaction():
+                        tournament = await Tournament.create(name='Nested')
+                        saved_tournament = await Tournament.filter(name='Nested').first()
+                        self.assertEqual(tournament.id, saved_tournament.id)
+                        raise SomeException('Some error')
+                except TransactionManagementError:
+                    raise test.SkipTest('Nested transactions not supported by SQLite build')
 
         saved_event = await Tournament.filter(name='Updated name').first()
         self.assertIsNotNone(saved_event)

--- a/tortoise/tests/test_transactions.py
+++ b/tortoise/tests/test_transactions.py
@@ -1,20 +1,27 @@
 from tortoise.contrib import test
-from tortoise.exceptions import OperationalError
+from tortoise.exceptions import OperationalError, TransactionManagementError
 from tortoise.tests.testmodels import Tournament
-from tortoise.transactions import atomic, in_transaction
+from tortoise.transactions import atomic, in_transaction, start_transaction
+
+
+class SomeException(Exception):
+    """
+    A very specific exception so s to not accidentally catch another exception.
+    """
+    pass
 
 
 class TestTransactions(test.IsolatedTestCase):
 
     async def test_transactions(self):
-        with self.assertRaises(OperationalError):
-            async with in_transaction() as connection:
+        with self.assertRaises(SomeException):
+            async with in_transaction():
                 tournament = Tournament(name='Test')
                 await tournament.save()
                 await Tournament.filter(id=tournament.id).update(name='Updated name')
                 saved_event = await Tournament.filter(name='Updated name').first()
                 self.assertEqual(saved_event.id, tournament.id)
-                await connection.execute_query('SELECT * FROM non_existent_table')
+                raise SomeException('Some error')
 
         saved_event = await Tournament.filter(name='Updated name').first()
         self.assertIsNone(saved_event)
@@ -26,12 +33,12 @@ class TestTransactions(test.IsolatedTestCase):
             await Tournament.filter(id=tournament.id).update(name='Updated name')
             saved_event = await Tournament.filter(name='Updated name').first()
             self.assertEqual(saved_event.id, tournament.id)
-            with self.assertRaises(OperationalError):
-                async with in_transaction() as connection:
+            with self.assertRaises(SomeException):
+                async with in_transaction():
                     tournament = await Tournament.create(name='Nested')
                     saved_tournament = await Tournament.filter(name='Nested').first()
                     self.assertEqual(tournament.id, saved_tournament.id)
-                    await connection.execute_query('SELECT * FROM non_existent_table')
+                    raise SomeException('Some error')
 
         saved_event = await Tournament.filter(name='Updated name').first()
         self.assertIsNotNone(saved_event)
@@ -40,9 +47,23 @@ class TestTransactions(test.IsolatedTestCase):
 
     async def test_transaction_decorator(self):
         @atomic()
-        async def bound_to_fall():
+        async def bound_to_succeed():
             tournament = Tournament(name='Test')
             await tournament.save()
+            await Tournament.filter(id=tournament.id).update(name='Updated name')
+            saved_event = await Tournament.filter(name='Updated name').first()
+            self.assertEqual(saved_event.id, tournament.id)
+            return tournament
+
+        tournament = await bound_to_succeed()
+        saved_event = await Tournament.filter(name='Updated name').first()
+        self.assertEqual(saved_event.id, tournament.id)
+
+    async def test_transaction_decorator_fail(self):
+        tournament = await Tournament.create(name='Test')
+
+        @atomic()
+        async def bound_to_fall():
             await Tournament.filter(id=tournament.id).update(name='Updated name')
             saved_event = await Tournament.filter(name='Updated name').first()
             self.assertEqual(saved_event.id, tournament.id)
@@ -50,5 +71,55 @@ class TestTransactions(test.IsolatedTestCase):
 
         with self.assertRaises(OperationalError):
             await bound_to_fall()
+        saved_event = await Tournament.filter(name='Test').first()
+        self.assertEqual(saved_event.id, tournament.id)
         saved_event = await Tournament.filter(name='Updated name').first()
         self.assertIsNone(saved_event)
+
+    async def test_transaction_manual_commit(self):
+        tournament = await Tournament.create(name='Test')
+
+        connection = await start_transaction()
+        await Tournament.filter(id=tournament.id).update(name='Updated name')
+        saved_event = await Tournament.filter(name='Updated name').first()
+        self.assertEqual(saved_event.id, tournament.id)
+        await connection.commit()
+
+        saved_event = await Tournament.filter(name='Updated name').first()
+        self.assertEqual(saved_event.id, tournament.id)
+
+    async def test_transaction_manual_rollback(self):
+        tournament = await Tournament.create(name='Test')
+
+        connection = await start_transaction()
+        await Tournament.filter(id=tournament.id).update(name='Updated name')
+        saved_event = await Tournament.filter(name='Updated name').first()
+        self.assertEqual(saved_event.id, tournament.id)
+        await connection.rollback()
+
+        saved_event = await Tournament.filter(name='Test').first()
+        self.assertEqual(saved_event.id, tournament.id)
+        saved_event = await Tournament.filter(name='Updated name').first()
+        self.assertIsNone(saved_event)
+
+    async def test_transaction_exception_1(self):
+        connection = await start_transaction()
+        await connection.rollback()
+        with self.assertRaises(TransactionManagementError):
+            await connection.rollback()
+
+    async def test_transaction_exception_2(self):
+        with self.assertRaises(TransactionManagementError):
+            async with in_transaction() as connection:
+                await connection.rollback()
+
+    async def test_transaction_exception_3(self):
+        connection = await start_transaction()
+        await connection.commit()
+        with self.assertRaises(TransactionManagementError):
+            await connection.commit()
+
+    async def test_transaction_exception_4(self):
+        with self.assertRaises(TransactionManagementError):
+            async with in_transaction() as connection:
+                await connection.commit()

--- a/tortoise/tests/test_two_databases.py
+++ b/tortoise/tests/test_two_databases.py
@@ -9,11 +9,11 @@ class TestTwoDatabases(test.SimpleTestCase):
     async def setUp(self):
         if Tortoise._inited:
             await self._tearDownDB()
-        first_db_config = self.getDBConfig(
+        first_db_config = test.getDBConfig(
             app_label='models',
             model_modules=['tortoise.tests.testmodels'],
         )
-        second_db_config = self.getDBConfig(
+        second_db_config = test.getDBConfig(
             app_label='events',
             model_modules=['tortoise.tests.testmodels'],
         )


### PR DESCRIPTION
Fixed `test.TestCase` to isolate the DB so that tests can now be wrapped in transactions.
PostgreSQL all working.

* [x] SQLite needed to have its connection infrastructure refactored so that transactions will actually run in a transaction.
* [x] Added more tests and a special exception type for transactions.
* [x] Handle exception when nested transaction not available due to build-time option.
* [x] Removed implicit commit at excute_query, which caused some transaction weirdness in SQLite
* [x] Test runner requires an `initializer()` and `finalizer()` to set up db and tear down db cleanly.